### PR TITLE
Bump to {glib,gobject}-sys 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,11 +3,11 @@ name = "gstreamer-video-sys"
 version = "0.1.1"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-base-sys 0.1.1",
  "gstreamer-sys 0.1.1",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -18,22 +18,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "glib-sys"
-version = "0.3.4"
-source = "git+https://github.com/gtk-rs/sys#af83826e0a31f68bcddee17d3791fb01453dc632"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gobject-sys"
-version = "0.3.4"
-source = "git+https://github.com/gtk-rs/sys#af83826e0a31f68bcddee17d3791fb01453dc632"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -42,11 +42,11 @@ name = "gstreamer-app-sys"
 version = "0.1.1"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-base-sys 0.1.1",
  "gstreamer-sys 0.1.1",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -55,12 +55,12 @@ name = "gstreamer-audio-sys"
 version = "0.1.1"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-base-sys 0.1.1",
  "gstreamer-sys 0.1.1",
  "gstreamer-tag-sys 0.1.1",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -69,10 +69,10 @@ name = "gstreamer-base-sys"
 version = "0.1.1"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-sys 0.1.1",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -81,13 +81,13 @@ name = "gstreamer-pbutils-sys"
 version = "0.1.1"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-audio-sys 0.1.1",
  "gstreamer-sys 0.1.1",
  "gstreamer-tag-sys 0.1.1",
  "gstreamer-video-sys 0.1.1",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -96,11 +96,11 @@ name = "gstreamer-player-sys"
 version = "0.1.1"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-sys 0.1.1",
  "gstreamer-video-sys 0.1.1",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -109,9 +109,9 @@ name = "gstreamer-sys"
 version = "0.1.1"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -120,17 +120,17 @@ name = "gstreamer-tag-sys"
 version = "0.1.1"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
- "gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)",
+ "glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-base-sys 0.1.1",
  "gstreamer-sys 0.1.1",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -140,7 +140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-"checksum glib-sys 0.3.4 (git+https://github.com/gtk-rs/sys)" = "<none>"
-"checksum gobject-sys 0.3.4 (git+https://github.com/gtk-rs/sys)" = "<none>"
-"checksum libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb7b49972ee23d8aa1026c365a5b440ba08e35075f18c459980c7395c221ec48"
+"checksum glib-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd7d911c5dc610aabe37caae7d3b9d2cfe6d8f4c85ff4c062f3d6f490e75067"
+"checksum gobject-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edc95561e538381576425264a4ddd08c65d5da218f10b2a47b4479dd147775da"
+"checksum libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "8a014d9226c2cc402676fbe9ea2e15dd5222cd1dd57f576b5b283178c944a264"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"

--- a/gstreamer-app-sys/Cargo.toml
+++ b/gstreamer-app-sys/Cargo.toml
@@ -4,8 +4,8 @@ pkg-config = "0.3.7"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 
 [dependencies.gstreamer-sys]
 path = "../gstreamer-sys"

--- a/gstreamer-audio-sys/Cargo.toml
+++ b/gstreamer-audio-sys/Cargo.toml
@@ -4,8 +4,8 @@ pkg-config = "0.3.7"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 
 [dependencies.gstreamer-sys]
 path = "../gstreamer-sys"

--- a/gstreamer-base-sys/Cargo.toml
+++ b/gstreamer-base-sys/Cargo.toml
@@ -4,8 +4,8 @@ pkg-config = "0.3.7"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 
 [dependencies.gstreamer-sys]
 path = "../gstreamer-sys"

--- a/gstreamer-pbutils-sys/Cargo.toml
+++ b/gstreamer-pbutils-sys/Cargo.toml
@@ -4,8 +4,8 @@ pkg-config = "0.3.7"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 
 [dependencies.gstreamer-sys]
 path = "../gstreamer-sys"

--- a/gstreamer-player-sys/Cargo.toml
+++ b/gstreamer-player-sys/Cargo.toml
@@ -4,8 +4,8 @@ pkg-config = "0.3.7"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 
 [dependencies.gstreamer-sys]
 path = "../gstreamer-sys"

--- a/gstreamer-sys/Cargo.toml
+++ b/gstreamer-sys/Cargo.toml
@@ -4,8 +4,8 @@ pkg-config = "0.3.7"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 
 [features]
 v1_0_10 = []

--- a/gstreamer-tag-sys/Cargo.toml
+++ b/gstreamer-tag-sys/Cargo.toml
@@ -4,8 +4,8 @@ pkg-config = "0.3.7"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 
 [dependencies.gstreamer-sys]
 path = "../gstreamer-sys"

--- a/gstreamer-video-sys/Cargo.toml
+++ b/gstreamer-video-sys/Cargo.toml
@@ -4,8 +4,8 @@ pkg-config = "0.3.7"
 [dependencies]
 bitflags = "0.9"
 libc = "0.2"
-glib-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { version = "0.3.4", git = "https://github.com/gtk-rs/sys" }
+glib-sys = "0.4.0"
+gobject-sys = "0.4.0"
 
 [dependencies.gstreamer-sys]
 path = "../gstreamer-sys"


### PR DESCRIPTION
The 0.3.4 version is no longer available in Github.